### PR TITLE
fix: restric origin to localhost for dev

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -17,7 +17,10 @@ class App {
     this.app.use(requestInfo);
     this.app.use(
       cors({
-        origin: "*",
+        origin:
+          process.env.NODE_ENV == "prod"
+            ? process.env.ORIGIN
+            : "http://localhost:3000",
         allowedHeaders: "*",
       })
     );


### PR DESCRIPTION
## Description 

The Sonar was pointing out some problems with the cors due to the origin that was set. I restricted it to use the localhost for dev env and then get it from the env for production enviroemnt 